### PR TITLE
feat: add configurable progress bar to SVG output

### DIFF
--- a/command.go
+++ b/command.go
@@ -436,6 +436,7 @@ var Settings = map[string]CommandFunc{
 	"WaitPattern":         ExecuteSetWaitPattern,
 	"WaitTimeout":         ExecuteSetWaitTimeout,
 	"CursorBlink":         ExecuteSetCursorBlink,
+	"ProgressBar":         ExecuteSetProgressBar,
 }
 
 // ExecuteSet applies the settings on the running vhs specified by the
@@ -652,6 +653,12 @@ func ExecuteLoopOffset(c parser.Command, v *VHS) error {
 // ExecuteSetMarginFill sets vhs margin fill.
 func ExecuteSetMarginFill(c parser.Command, v *VHS) error {
 	v.Options.Video.Style.MarginFill = c.Args
+	return nil
+}
+
+// ExecuteSetProgressBar sets the progress bar color.
+func ExecuteSetProgressBar(c parser.Command, v *VHS) error {
+	v.Options.Video.Style.ProgressBarColor = c.Args
 	return nil
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -505,6 +505,27 @@ func (p *Parser) parseSet() Command {
 				)
 			}
 		}
+	case token.PROGRESS_BAR:
+		cmd.Args = p.peek.Literal
+		p.nextToken()
+
+		progressBar := p.cur.Literal
+
+		// Validate hex color: #RGB, #RRGGBB, or #RRGGBBAA
+		if strings.HasPrefix(progressBar, "#") {
+			hex := progressBar[1:]
+			_, err := strconv.ParseUint(hex, 16, 64)
+
+			if err != nil || (len(hex) != 3 && len(hex) != 6 && len(hex) != 8) {
+				p.errors = append(
+					p.errors,
+					NewError(
+						p.cur,
+						"\""+progressBar+"\" is not a valid color. Use #RGB, #RRGGBB, or #RRGGBBAA.",
+					),
+				)
+			}
+		}
 	case token.CURSOR_BLINK:
 		cmd.Args = p.peek.Literal
 		p.nextToken()

--- a/style.go
+++ b/style.go
@@ -75,6 +75,7 @@ type StyleOptions struct {
 	FontSize            int    // Font size passed from VHS options
 	WindowBarFontFamily string // Font family specifically for window bar title
 	WindowBarFontSize   int    // Font size specifically for window bar title
+	ProgressBarColor    string // Color for progress bar (empty = no bar)
 }
 
 // DefaultStyleOptions returns default Style config.

--- a/token/token.go
+++ b/token/token.go
@@ -106,6 +106,7 @@ const (
 	WAIT_TIMEOUT           = "WAIT_TIMEOUT"           //nolint:revive
 	WAIT_PATTERN           = "WAIT_PATTERN"           //nolint:revive
 	CURSOR_BLINK           = "CURSOR_BLINK"           //nolint:revive
+	PROGRESS_BAR           = "PROGRESS_BAR"           //nolint:revive
 )
 
 // Keywords maps keyword strings to tokens.
@@ -165,6 +166,7 @@ var Keywords = map[string]Type{
 	"Wait":                WAIT,
 	"Source":              SOURCE,
 	"CursorBlink":         CURSOR_BLINK,
+	"ProgressBar":         PROGRESS_BAR,
 	"true":                BOOLEAN,
 	"false":               BOOLEAN,
 	"Screenshot":          SCREENSHOT,
@@ -179,7 +181,7 @@ func IsSetting(t Type) bool {
 	case SHELL, FONT_FAMILY, FONT_SIZE, LETTER_SPACING, LINE_HEIGHT,
 		FRAMERATE, TYPING_SPEED, THEME, PLAYBACK_SPEED, HEIGHT, WIDTH,
 		PADDING, LOOP_OFFSET, MARGIN_FILL, MARGIN, WINDOW_BAR,
-		WINDOW_BAR_SIZE, WINDOW_BAR_TITLE, WINDOW_BAR_FONT_FAMILY, WINDOW_BAR_FONT_SIZE, BORDER_RADIUS, CURSOR_BLINK, WAIT_TIMEOUT, WAIT_PATTERN:
+		WINDOW_BAR_SIZE, WINDOW_BAR_TITLE, WINDOW_BAR_FONT_FAMILY, WINDOW_BAR_FONT_SIZE, BORDER_RADIUS, CURSOR_BLINK, PROGRESS_BAR, WAIT_TIMEOUT, WAIT_PATTERN:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
- Add `Set ProgressBar <color>` command to tape files for an animated progress bar in SVG output
- The 1px bar grows left to right over the animation duration, providing visual feedback during playback
- Supports `#RGB`, `#RRGGBB`, and `#RRGGBBAA` hex colors (RGBA for semi-transparent bars)
- Opt-in: no progress bar by default, only rendered when a color is explicitly set

## Usage
```
Set ProgressBar "#9B79FF"
```

For a semi-transparent bar:
```
Set ProgressBar "#9B79FF80"
```

## Implementation
- Full tape command pipeline: token → lexer → parser (with color validation) → command execution → SVG generation
- Bar is placed inside the inner SVG so CSS animation works in non-browser renderers (librsvg, Inkscape)
- Animation duration and delay are synchronized with the main slide animation

## Test plan
- [x] `TestParseProgressBar` — valid hex colors (#RGB, #RRGGBB, #RRGGBBAA) parse correctly; invalid colors produce errors
- [x] `TestSVGGenerator_ProgressBar` — no bar by default, renders with color, supports RGBA, bar is inside inner SVG, animation duration matches slide
- [x] Full test suite passes (`go test ./...`)